### PR TITLE
Updated ActiveDirectoryAppUser to handle null DisplayName attribute.

### DIFF
--- a/IdentityServer.LdapExtension.Unit/UserStores/InMemoryUserStoreTests.cs
+++ b/IdentityServer.LdapExtension.Unit/UserStores/InMemoryUserStoreTests.cs
@@ -2,6 +2,7 @@
 using IdentityServer.LdapExtension.UserModel;
 using IdentityServer.LdapExtension.UserStore;
 using Moq;
+using Novell.Directory.Ldap;
 using System;
 using Xunit;
 
@@ -113,6 +114,25 @@ namespace IdentityServer.LdapExtension.Unit.UserStores
 
             Assert.Equal(default(OpenLdapAppUser), user);
             _authenticationService.VerifyAll();
+        }
+
+        [Fact]
+        public void ActiveDirectoryAttributeDisplayNameIsNull_SetsAppUserDisplayNameNull()
+        {
+            var ldapAttributeSet = new LdapAttributeSet();
+            ldapAttributeSet.Add(new LdapAttribute("distinguishedName", "cn=testuser,cn=users,dc=example,dc=com"));
+            ldapAttributeSet.Add(new LdapAttribute("cn", "testuser"));
+            ldapAttributeSet.Add(new LdapAttribute("givenName", "Test"));
+            ldapAttributeSet.Add(new LdapAttribute("name", "testuser"));
+            ldapAttributeSet.Add(new LdapAttribute("userPrincipalName", "testuser@example.com"));
+            ldapAttributeSet.Add(new LdapAttribute("sAMAccountName", "testuser"));
+
+            var ldapEntry = new LdapEntry("cn=testuser,cn=users,dc=example,dc=com", ldapAttributeSet);
+
+            var appUser = new ActiveDirectoryAppUser();
+            appUser.SetBaseDetails(ldapEntry, "local");
+
+            Assert.Null(appUser.DisplayName);
         }
     }
 }

--- a/IdentityServer.LdapExtension/UserModel/ActiveDirectoryAppUser.cs
+++ b/IdentityServer.LdapExtension/UserModel/ActiveDirectoryAppUser.cs
@@ -127,7 +127,7 @@ namespace IdentityServer.LdapExtension.UserModel
         /// <param name="providerName">Specific provider such as Google, Facebook, etc.</param>
         public void SetBaseDetails(LdapEntry ldapEntry, string providerName)
         {
-            DisplayName = ldapEntry.getAttribute(ActiveDirectoryLdapAttributes.DisplayName.ToDescriptionString()).StringValue;
+            DisplayName = ldapEntry.getAttribute(ActiveDirectoryLdapAttributes.DisplayName.ToDescriptionString())?.StringValue;
             Username = ldapEntry.getAttribute(ActiveDirectoryLdapAttributes.UserName.ToDescriptionString()).StringValue;
             ProviderName = providerName;
             SubjectId = Username; // We could use the uidNumber instead in a sha algo.


### PR DESCRIPTION
DisplayName attribute in ActiveDirectory may not be set for a user and currently this causes an Invalid username/password error when attempting to login as the user without a DisplayName attribute. 

Fixes #9 