### PR TITLE
Fixed concurrency bug in LdapService

### DIFF
--- a/IdentityServer.LdapExtension/IdentityServer.LdapExtension.csproj
+++ b/IdentityServer.LdapExtension/IdentityServer.LdapExtension.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Nordès Ménard-Lamarre</Authors>
-    <Version>2.0.0</Version>
+    <Version>2.1.14</Version>
     <Company>HoNoSoFt</Company>
     <Description>Extension for IdentityServer 4 in order to use LDAP as a plugin. It is also extensible enough in order to use custom LDAP schema such as OpenLdap or Active Directory.</Description>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>


### PR DESCRIPTION
The current ``LdapService`` implementation is not thread safe. However it is called by concurrent threads when added via ``AddLdapUsers()``. 

This fix ensures thread safety in ``LdapService``: A new connection per call of ``SearchUser()`` ensures that one connection will not be used by concurrent threads at the same time.