### PR TITLE
Oracle ldap and some code review

### DIFF
--- a/IdentityServer.LdapExtension/Extensions/AddLdapUsersExtension.cs
+++ b/IdentityServer.LdapExtension/Extensions/AddLdapUsersExtension.cs
@@ -49,7 +49,6 @@ namespace IdentityServer.LdapExtension.Extensions
         /// <typeparam name="TCustomUserStore">The type of the custom user store.</typeparam>
         /// <param name="builder">The builder.</param>
         /// <param name="configuration">The ldap configuration.</param>
-        /// <param name="customUserStore">The custom user store (ILdapUserStore).</param>
         /// <returns>
         /// Returns the builder instance
         /// </returns>

--- a/IdentityServer.LdapExtension/Extensions/EnumExtension.cs
+++ b/IdentityServer.LdapExtension/Extensions/EnumExtension.cs
@@ -24,7 +24,15 @@ namespace IdentityServer.LdapExtension.Extensions
                 List<string> result = new List<string>();
                 foreach (var e in Enum.GetValues(typeof(T)))
                 {
-                    var fi = e.GetType().GetField(e.ToString());
+                    var fieldName = e.ToString();
+                    if(string.IsNullOrEmpty(fieldName))
+                        continue;
+                    
+                    var fi = e.GetType().GetField(fieldName);
+                    
+                    if(fi == null)
+                        continue;
+                    
                     var attributes = (DescriptionAttribute[])fi.GetCustomAttributes(typeof(DescriptionAttribute), false);
                     var description = attributes[0].Description;
                     if (!result.Contains(description))

--- a/IdentityServer.LdapExtension/LdapService.cs
+++ b/IdentityServer.LdapExtension/LdapService.cs
@@ -93,7 +93,6 @@ namespace IdentityServer.LdapExtension
         /// Finds user by username.
         /// </summary>
         /// <param name="username">The username.</param>
-        /// <param name="domain">The domain friendly name.</param>
         /// <returns>
         /// Returns the user when it exists.
         /// </returns>
@@ -148,7 +147,7 @@ namespace IdentityServer.LdapExtension
                 allSearcheable = allSearcheable.Where(e => e.FriendlyName.Equals(domain)).ToList();
             }
 
-            if (allSearcheable == null || allSearcheable.Count() == 0)
+            if (allSearcheable == null || allSearcheable.Count == 0)
             {
                 throw new LoginFailedException(
                     "Login failed.",
@@ -158,9 +157,7 @@ namespace IdentityServer.LdapExtension
             // Could become async
             foreach (var matchConfig in allSearcheable)
             {
-                using(var ldapConnection = new LdapConnection {
-                    SecureSocketLayer = matchConfig.Ssl
-                })
+                using(var ldapConnection = new LdapConnection {SecureSocketLayer = matchConfig.Ssl})
                 {
                     ldapConnection.Connect(matchConfig.Url, matchConfig.FinalLdapConnectionPort);
                     ldapConnection.Bind(matchConfig.BindDn, matchConfig.BindCredentials);

--- a/IdentityServer.LdapExtension/UserModel/ActiveDirectoryLdapAttributes.cs
+++ b/IdentityServer.LdapExtension/UserModel/ActiveDirectoryLdapAttributes.cs
@@ -6,26 +6,36 @@ namespace IdentityServer.LdapExtension.UserModel
 {
     public enum ActiveDirectoryLdapAttributes
     {
-        [Description("displayName")]
+        [Description("displayName")] 
         DisplayName,
-        [Description("givenName")]
+        
+        [Description("givenName")] 
         FirstName,
+        
         [Description("sn")] // Surname
         LastName,
-        [Description("description")]
+        
+        [Description("description")] 
         Description,
-        [Description("telephoneNumber")]
+        
+        [Description("telephoneNumber")] 
         TelephoneNumber,
+
         [Description("name")] // Also used as user name
         Name,
-        [Description("whenCreated")]
+        
+        [Description("whenCreated")] 
         CreatedOn,
-        [Description("whenChanged")]
+        
+        [Description("whenChanged")] 
         UpdatedOn,
-        [Description("sAMAccountName")]
+        
+        [Description("sAMAccountName")] 
         UserName,
-        [Description("mail")]
+        
+        [Description("mail")] 
         EMail,
+
         [Description("memberOf")] // Groups attribute that can appears multiple time
         MemberOf
     }
@@ -49,8 +59,17 @@ namespace IdentityServer.LdapExtension.UserModel
             List<string> result = new List<string>();
             foreach (var e in Enum.GetValues(typeof(T)))
             {
-                var fi = e.GetType().GetField(e.ToString());
-                var attributes = (DescriptionAttribute[])fi.GetCustomAttributes(typeof(DescriptionAttribute), false);
+                var fieldName = e.ToString();
+
+                if (string.IsNullOrEmpty(fieldName))
+                    continue;
+
+                var field = e.GetType().GetField(fieldName);
+
+                if (field == null)
+                    continue;
+
+                var attributes = (DescriptionAttribute[]) field.GetCustomAttributes(typeof(DescriptionAttribute), false);
                 var description = attributes[0].Description;
                 if (!result.Contains(description))
                 {
@@ -63,8 +82,8 @@ namespace IdentityServer.LdapExtension.UserModel
 
         public static string ToDescriptionString(this ActiveDirectoryLdapAttributes val)
         {
-            DescriptionAttribute[] attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
-            return attributes.Length > 0 ? attributes[0].Description : string.Empty;
+            DescriptionAttribute[] attributes = (DescriptionAttribute[]) val.GetType().GetField(val.ToString())?.GetCustomAttributes(typeof(DescriptionAttribute), false);
+            return attributes != null && attributes.Length > 0 ? attributes[0].Description : string.Empty;
         }
     }
 }

--- a/IdentityServer.LdapExtension/UserModel/IAppUser.cs
+++ b/IdentityServer.LdapExtension/UserModel/IAppUser.cs
@@ -32,6 +32,7 @@ namespace IdentityServer.LdapExtension.UserModel
         /// </summary>
         /// <param name="ldapEntry">Ldap Entry</param>
         /// <param name="providerName">Specific provider such as Google, Facebook, etc.</param>
+        /// <param name="extraFields">Ldap configuration extra fields</param>
         void SetBaseDetails(LdapEntry ldapEntry, string providerName, IEnumerable<string> extraFields = null);
     }
 }

--- a/IdentityServer.LdapExtension/UserModel/OpenLdapAttributes.cs
+++ b/IdentityServer.LdapExtension/UserModel/OpenLdapAttributes.cs
@@ -6,22 +6,30 @@ namespace IdentityServer.LdapExtension.UserModel
 {
     public enum OpenLdapAttributes
     {
-        [Description("displayName")]
+        [Description("displayName")] 
         DisplayName,
-        [Description("givenName")]
+        
+        [Description("givenName")] 
         FirstName,
+
         [Description("sn")] // Surname
         LastName,
-        [Description("description")]
+        
+        [Description("description")] 
         Description,
-        [Description("telephoneNumber")]
+        
+        [Description("telephoneNumber")] 
         TelephoneNumber,
+
         [Description("uid")] // Also used as user name
         Name,
-        [Description("uid")]
+        
+        [Description("uid")] 
         UserName,
+        
         [Description("mail")]
         EMail,
+
         [Description("memberOf")] // Groups attribute that can appears multiple time
         MemberOf
     }
@@ -45,8 +53,17 @@ namespace IdentityServer.LdapExtension.UserModel
             List<string> result = new List<string>();
             foreach (var e in Enum.GetValues(typeof(T)))
             {
-                var fi = e.GetType().GetField(e.ToString());
-                var attributes = (DescriptionAttribute[])fi.GetCustomAttributes(typeof(DescriptionAttribute), false);
+                var fieldName = e.ToString();
+
+                if (string.IsNullOrEmpty(fieldName))
+                    continue;
+
+                var field = e.GetType().GetField(fieldName);
+
+                if(field == null)
+                    continue;
+                
+                var attributes = (DescriptionAttribute[]) field.GetCustomAttributes(typeof(DescriptionAttribute), false);
                 var description = attributes[0].Description;
                 if (!result.Contains(description))
                 {
@@ -59,8 +76,8 @@ namespace IdentityServer.LdapExtension.UserModel
 
         public static string ToDescriptionString(this OpenLdapAttributes val)
         {
-            DescriptionAttribute[] attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
-            return attributes.Length > 0 ? attributes[0].Description : string.Empty;
+            DescriptionAttribute[] attributes = (DescriptionAttribute[]) val.GetType().GetField(val.ToString())?.GetCustomAttributes(typeof(DescriptionAttribute), false);
+            return attributes != null && attributes.Length > 0 ? attributes[0].Description : string.Empty;
         }
     }
 }

--- a/IdentityServer.LdapExtension/UserModel/OracleLdapAppUser.cs
+++ b/IdentityServer.LdapExtension/UserModel/OracleLdapAppUser.cs
@@ -120,7 +120,14 @@ namespace IdentityServer.LdapExtension.UserModel
         public void SetBaseDetails(LdapEntry ldapEntry, string providerName, IEnumerable<string> extraFields = null)
         {
             //Display name not required on oracle ldap
-            //DisplayName = ldapEntry.GetAttribute(OpenLdapAttributes.DisplayName.ToDescriptionString()).StringValue;
+            try
+            {
+                DisplayName = ldapEntry.GetAttribute(OpenLdapAttributes.DisplayName.ToDescriptionString()).StringValue;
+            }
+            catch
+            {
+                //ignored
+            }
             Username = ldapEntry.GetAttribute(OpenLdapAttributes.UserName.ToDescriptionString()).StringValue;
             ProviderName = providerName;
             SubjectId = Username; // Extra: We could use the uidNumber instead in a sha algo.

--- a/IdentityServer.LdapExtension/UserModel/OracleLdapAppUser.cs
+++ b/IdentityServer.LdapExtension/UserModel/OracleLdapAppUser.cs
@@ -13,7 +13,7 @@ namespace IdentityServer.LdapExtension.UserModel
     /// </summary>
     /// <seealso cref="IdentityServer.LdapExtension.UserModel.IAppUser" />
     /// <remarks>In the future, this might become a base class instead of inherithing from an interface.</remarks>
-    public class OpenLdapAppUser : IAppUser
+    public class OracleLdapAppUser : IAppUser
     {
         private string _subjectId;
 
@@ -43,7 +43,7 @@ namespace IdentityServer.LdapExtension.UserModel
         /// Fills the claims.
         /// </summary>
         /// <param name="user">The user.</param>
-        public void FillClaims(LdapEntry user)
+        private void FillClaims(LdapEntry user)
         {
             // Example in LDAP we have display name as displayName (normal field)
             this.Claims = new List<Claim>
@@ -119,7 +119,8 @@ namespace IdentityServer.LdapExtension.UserModel
 
         public void SetBaseDetails(LdapEntry ldapEntry, string providerName, IEnumerable<string> extraFields = null)
         {
-            DisplayName = ldapEntry.GetAttribute(OpenLdapAttributes.DisplayName.ToDescriptionString()).StringValue;
+            //Display name not required on oracle ldap
+            //DisplayName = ldapEntry.GetAttribute(OpenLdapAttributes.DisplayName.ToDescriptionString()).StringValue;
             Username = ldapEntry.GetAttribute(OpenLdapAttributes.UserName.ToDescriptionString()).StringValue;
             ProviderName = providerName;
             SubjectId = Username; // Extra: We could use the uidNumber instead in a sha algo.

--- a/IdentityServer.LdapExtension/UserStore/InMemoryUserStore.cs
+++ b/IdentityServer.LdapExtension/UserStore/InMemoryUserStore.cs
@@ -1,7 +1,6 @@
 ﻿using IdentityModel;
 using IdentityServer.LdapExtension.Exceptions;
 using IdentityServer.LdapExtension.UserModel;
-using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;

--- a/IdentityServer.LdapExtension/UserStore/RedisUserStore.cs
+++ b/IdentityServer.LdapExtension/UserStore/RedisUserStore.cs
@@ -33,8 +33,6 @@ namespace IdentityServer.LdapExtension.UserStore
             Formatting = Formatting.Indented
         };
 
-        private TimeSpan _dataExpireIn;
-
         public RedisUserStore(
             ILdapService<TUser> authenticationService,
             ExtensionConfig ldapConfigurations,
@@ -62,8 +60,6 @@ namespace IdentityServer.LdapExtension.UserStore
             {
                 _logger.LogError($"LDAP {GetType().Name}: Not able to connect to redis :(");
             }
-
-            _dataExpireIn = TimeSpan.FromSeconds(config.RefreshClaimsInSeconds ?? (double)-1);
         }
 
         /// <summary>


### PR DESCRIPTION
The display name feature is not required in Oracle LDAP. This parameter would cause an error when null. That's why OracleLdapAppUser was added.

https://docs.oracle.com/middleware/12211/edq/secure/ldap.htm#DQSEC964
